### PR TITLE
MATRIX-7880: update new lines handling

### DIFF
--- a/js/htmldiff.js
+++ b/js/htmldiff.js
@@ -332,7 +332,10 @@
             return '<' + (tagName[1].toLowerCase()) + '>';
         }
 
-        // Otherwise, the token is text, collapse the whitespace (except new lines)
+        // Otherwise, the token is text, collapse the whitespace
+        // (except new lines, see https://matrixreq.atlassian.net/browse/MATRIX-7880)
+        // potentially, this also causing the problems with prettified HTML (with "\n" between the tags),
+        // so it's required to "flatten" html before passing it to the diffing function
         if (token) {
             return token.replace(/([^\S\r\n]+|&nbsp;|&#160;)/g, ' ');
         }

--- a/js/htmldiff.js
+++ b/js/htmldiff.js
@@ -332,9 +332,9 @@
             return '<' + (tagName[1].toLowerCase()) + '>';
         }
 
-        // Otherwise, the token is text, collapse the whitespace.
+        // Otherwise, the token is text, collapse the whitespace (except new lines)
         if (token) {
-            return token.replace(/(\s+|&nbsp;|&#160;)/g, ' ');
+            return token.replace(/([^\S\r\n]+|&nbsp;|&#160;)/g, ' ');
         }
         return token;
     }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "@matrixreq/htmldiff",
     "description": "Diff and markup HTML with <ins> and <del> tags",
     "companyname": "Matrix Requirements",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "keywords": [
         "diff",
         "html",

--- a/test/diff.spec.js
+++ b/test/diff.spec.js
@@ -29,9 +29,9 @@ describe('Diff', function(){
   
     describe('Whitespace differences', function(){
       it('should collapse adjacent whitespace', function(){
-        expect(cut('Much \n\t    spaces', 'Much spaces')).to.equal('Much spaces');
+        expect(cut('Much \t    spaces', 'Much spaces')).to.equal('Much spaces');
       });
-  
+
       it('should consider non-breaking spaces as equal', function(){
         expect(cut('Hello&nbsp;world', 'Hello&#160;world')).to.equal('Hello&#160;world');
       });

--- a/test/edge_cases.spec.js
+++ b/test/edge_cases.spec.js
@@ -2,30 +2,32 @@ const diff = require('../js/htmldiff');
 
 describe('Edge cases', () => {
     it('removes deleted closing-opening tag pair', () => {
-        const before = `
-            <div>
-                <p><img src="img1.jpg" /></p>
-                <p><img src="img2.jpg" /></p>
-                <p>something</p>
-            </div>
-        `;
-        const after = `
-            <div>
-                <p>
-                    <img src="img1.jpg" />
-                    <img src="img2.jpg" />
-                </p>
-                <p>something</p>
-            </div>
-        `;
-        const res = `
-            <div>
-                <p><img src="img1.jpg" /><del>
-                </del><img src="img2.jpg" /></p>
-                <p>something</p>
-            </div>
-        `;
+        const before = `<div><p><img src="img1.jpg" /></p><p><img src="img2.jpg" /></p><p>something</p></div>`;
+        const after = `<div><p><img src="img1.jpg" /><img src="img2.jpg" /></p><p>something</p></div>`;
+        const res = `<div><p><img src="img1.jpg" /><del></del><img src="img2.jpg" /></p><p>something</p></div>`;
 
         expect(diff(before, after)).to.eql(res);
     });
+
+    it('preserves new lines', () => {
+        const before = `<div>this isain text control Donec ullamcorper tortor quis augue egestas ultricies. Aenean vehicula molestie ex. Praesent id dolor at mauris efficitur ultrices. Vestibulum rutrum sit amet odio quis gravida. Praesent id augue maximus, faucibus tellus in, mattis augue. Pellentesque ullamcorper, ante et vestibulum tempus, libero nisl consequat massa, vel aliquam massa nibh in sapie</div>`;
+        const after = `<div>this isain text control Donec ullamcorper tortor quis augue egestas ultricies. Aenean vehicula molestie ex. Praesent id do at mauris efficitur ultrices. Vestibulum rutrum sit amet odio quis gravida. Praesent id augue maximus, faucibus tellus in, mattisugue. Pellentesque ullamcorper, ante et  tempus, libero nisl consequat massa, vel aliquam massa nibh 
+
+jndfoewnf[owe 1123123242
+%^&amp;*()(*&amp;^%$#@#$%^&amp;*()
+
+BNXOISAN'FOSER3154
+65+
+5SSDC</div>`;
+        const res = `<div>this isain text control Donec ullamcorper tortor quis augue egestas ultricies. Aenean vehicula molestie ex. Praesent id <del data-operation-index="1">dolor</del><ins data-operation-index="1">do</ins> at mauris efficitur ultrices. Vestibulum rutrum sit amet odio quis gravida. Praesent id augue maximus, faucibus tellus in, <del data-operation-index="3">mattis augue.</del><ins data-operation-index="3">mattisugue.</ins> Pellentesque ullamcorper, ante et<del data-operation-index="5"> vestibulum</del>  tempus, libero nisl consequat massa, vel aliquam massa nibh<del data-operation-index="7"> in sapie</del><ins data-operation-index="7"> 
+
+jndfoewnf[owe 1123123242
+%^&amp;*()(*&amp;^%$#@#$%^&amp;*()
+
+BNXOISAN'FOSER3154
+65+
+5SSDC</ins></div>`;
+
+        expect(diff(before, after)).to.eql(res);
+    })
 });


### PR DESCRIPTION
[Ticket](https://matrixreq.atlassian.net/browse/MATRIX-7880)

update new lines handling. 
I think that this change actually causes quite heavy consequences, in a way that it will no longer be able to handle "prettified" html (with new lines between the tags, see previous version of "removes deleted closing-opening tag pair" spec). but since we're in full control of the html we're passing there, I'll make sure that we have a correct structure here (it actually already looks like we have a proper structure everywhere, but I would not rely on it staying that way)
https://github.com/MatrixRequirements/matrix-client-server/blob/ce05bdc0f81ec03f77fc9fae9fead51151ea95c6/server/Clouds/client/ts/sdk/utils/differs/diffHtml.ts#L23-L31

<img width="1470" alt="Screenshot 2024-09-12 at 17 30 35" src="https://github.com/user-attachments/assets/ffce48c0-9aac-451a-9125-f808c3ab5ba0">

