### PR TITLE
M3X-720: Enhance ins/del wrapping on atomic tags while diffing

### DIFF
--- a/js/htmldiff.js
+++ b/js/htmldiff.js
@@ -219,6 +219,8 @@
                     break;
                 case 'atomic_tag':
                     currentWord += char;
+                    // track the same name nested tags depth; 
+                    // end the atomic token only when it returns to 0.
                     if (isEndOfTag(char)){
                         var closedTag = lastClosedTag(currentWord);
                         if (closedTag && isClosingTagOf(closedTag, currentAtomicTag)){

--- a/js/htmldiff.js
+++ b/js/htmldiff.js
@@ -88,25 +88,30 @@
         return result && result[1];
     }
 
-    // inspect the last tag in word (from its opening '<'); to an earlier '>' in that
-    // slice means loose text e.g. "a > b" in a <script>, not a tag, so they bail out.
-
     /**
+     * Inspects the last tag in the given string its slice from the final '<'. A '>' before the slice's end
+     * means text follows e.g. "a > b" in a <script>, not a clean tag, so returns false.
      * @return {boolean} True if word ends with an opening (non-self-closing) tag for the given
-     *    atomic tag name.
+     *    tag name.
      */
     function isOpeningTagOf(word, tag){
         var tagText = word.substring(word.lastIndexOf('<'));
-        if (tagText.indexOf('>') !== tagText.length - 1) return false;
+        if (tagText.indexOf('>') !== tagText.length - 1) {
+            return false;
+        }
         return new RegExp('^<' + tag + '(\\s|>)').test(tagText) && !/\/>$/.test(tagText);
     }
 
     /**
-     * @return {boolean} True if word ends with a closing tag for the given atomic tag name.
+     * Inspects the last tag in the given string its slice from the final '<'. A '>' before the slice's end
+     * means text follows e.g. "a > b" in a <script>, not a clean tag, so returns false.
+     * @return {boolean} True if word ends with a closing tag for the given tag name.
      */
     function isClosingTagOf(word, tag){
         var tagText = word.substring(word.lastIndexOf('<'));
-        if (tagText.indexOf('>') !== tagText.length - 1) return false;
+        if (tagText.indexOf('>') !== tagText.length - 1) {
+            return false;
+        }
         return new RegExp('^</' + tag + '(\\s|>)').test(tagText);
     }
 

--- a/js/htmldiff.js
+++ b/js/htmldiff.js
@@ -88,31 +88,26 @@
         return result && result[1];
     }
 
-    /**
-     * Returns the just-closed tag (substring from the last '<') only when it is a clean
-     * single tag, so a stray '>' in text (e.g. "a > b" in a <script>) is not seen as a tag.
-     *
-     * @param {string} word The atomic token read so far, ending in '>'.
-     * @return {string|null} The tag text, or null if not a clean tag.
-     */
-    function lastClosedTag(word){
-        var tagText = word.substring(word.lastIndexOf('<'));
-        return tagText.indexOf('>') === tagText.length - 1 ? tagText : null;
-    }
+    // inspect the last tag in word (from its opening '<'); to an earlier '>' in that
+    // slice means loose text e.g. "a > b" in a <script>, not a tag, so they bail out.
 
     /**
-     * @return {boolean} True if tagText is a closing tag for the given atomic tag name.
-     */
-    function isClosingTagOf(tagText, tag){
-        return new RegExp('^</' + tag + '(\\s|>)').test(tagText);
-    }
-
-    /**
-     * @return {boolean} True if tagText is an opening (non-self-closing) tag for the given
+     * @return {boolean} True if word ends with an opening (non-self-closing) tag for the given
      *    atomic tag name.
      */
-    function isOpeningTagOf(tagText, tag){
+    function isOpeningTagOf(word, tag){
+        var tagText = word.substring(word.lastIndexOf('<'));
+        if (tagText.indexOf('>') !== tagText.length - 1) return false;
         return new RegExp('^<' + tag + '(\\s|>)').test(tagText) && !/\/>$/.test(tagText);
+    }
+
+    /**
+     * @return {boolean} True if word ends with a closing tag for the given atomic tag name.
+     */
+    function isClosingTagOf(word, tag){
+        var tagText = word.substring(word.lastIndexOf('<'));
+        if (tagText.indexOf('>') !== tagText.length - 1) return false;
+        return new RegExp('^</' + tag + '(\\s|>)').test(tagText);
     }
 
     /**
@@ -222,8 +217,7 @@
                     // track the same name nested tags depth; 
                     // end the atomic token only when it returns to 0.
                     if (isEndOfTag(char)){
-                        var closedTag = lastClosedTag(currentWord);
-                        if (closedTag && isClosingTagOf(closedTag, currentAtomicTag)){
+                        if (isClosingTagOf(currentWord, currentAtomicTag)){
                             currentAtomicTagDepth--;
                             if (currentAtomicTagDepth <= 0){
                                 words.push(createToken(currentWord));
@@ -232,7 +226,7 @@
                                 currentAtomicTagDepth = 0;
                                 mode = 'char';
                             }
-                        } else if (closedTag && isOpeningTagOf(closedTag, currentAtomicTag)){
+                        } else if (isOpeningTagOf(currentWord, currentAtomicTag)){
                             currentAtomicTagDepth++;
                         }
                     }

--- a/js/htmldiff.js
+++ b/js/htmldiff.js
@@ -89,17 +89,30 @@
     }
 
     /**
-     * Checks if the current word is the end of an atomic tag (i.e. it has all the characters,
-     * except for the end bracket of the closing tag, such as '<iframe></iframe').
+     * Returns the just-closed tag (substring from the last '<') only when it is a clean
+     * single tag, so a stray '>' in text (e.g. "a > b" in a <script>) is not seen as a tag.
      *
-     * @param {string} word The characters of the current token read so far.
-     * @param {string} tag The ending tag to look for.
-     *
-     * @return {boolean} True if the word is now a complete token (including the end tag),
-     *    false otherwise.
+     * @param {string} word The atomic token read so far, ending in '>'.
+     * @return {string|null} The tag text, or null if not a clean tag.
      */
-    function isEndOfAtomicTag(word, tag){
-        return word.substring(word.length - tag.length - 2) === ('</' + tag);
+    function lastClosedTag(word){
+        var tagText = word.substring(word.lastIndexOf('<'));
+        return tagText.indexOf('>') === tagText.length - 1 ? tagText : null;
+    }
+
+    /**
+     * @return {boolean} True if tagText is a closing tag for the given atomic tag name.
+     */
+    function isClosingTagOf(tagText, tag){
+        return new RegExp('^</' + tag + '(\\s|>)').test(tagText);
+    }
+
+    /**
+     * @return {boolean} True if tagText is an opening (non-self-closing) tag for the given
+     *    atomic tag name.
+     */
+    function isOpeningTagOf(tagText, tag){
+        return new RegExp('^<' + tag + '(\\s|>)').test(tagText) && !/\/>$/.test(tagText);
     }
 
     /**
@@ -175,6 +188,7 @@
         var mode = 'char';
         var currentWord = '';
         var currentAtomicTag = '';
+        var currentAtomicTagDepth = 0;
         var words = [];
         for (var i = 0; i < html.length; i++){
             var char = html[i];
@@ -184,6 +198,8 @@
                     if (atomicTag){
                         mode = 'atomic_tag';
                         currentAtomicTag = atomicTag;
+                        // skip standalone tags like <script> and <style>
+                        currentAtomicTagDepth = isEndOfTag(char) ? 1 : 0;
                         currentWord += char;
                     } else if (isStartofHTMLComment(currentWord)){
                         mode = 'html_comment';
@@ -202,14 +218,21 @@
                     }
                     break;
                 case 'atomic_tag':
-                    if (isEndOfTag(char) && isEndOfAtomicTag(currentWord, currentAtomicTag)){
-                        currentWord += '>';
-                        words.push(createToken(currentWord));
-                        currentWord = '';
-                        currentAtomicTag = '';
-                        mode = 'char';
-                    } else {
-                        currentWord += char;
+                    currentWord += char;
+                    if (isEndOfTag(char)){
+                        var closedTag = lastClosedTag(currentWord);
+                        if (closedTag && isClosingTagOf(closedTag, currentAtomicTag)){
+                            currentAtomicTagDepth--;
+                            if (currentAtomicTagDepth <= 0){
+                                words.push(createToken(currentWord));
+                                currentWord = '';
+                                currentAtomicTag = '';
+                                currentAtomicTagDepth = 0;
+                                mode = 'char';
+                            }
+                        } else if (closedTag && isOpeningTagOf(closedTag, currentAtomicTag)){
+                            currentAtomicTagDepth++;
+                        }
                     }
                     break;
                 case 'html_comment':

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "@matrixreq/htmldiff",
     "description": "Diff and markup HTML with <ins> and <del> tags",
     "companyname": "Matrix Requirements",
-    "version": "1.3.0",
+    "version": "1.4.0",
     "keywords": [
         "diff",
         "html",

--- a/test/html_to_tokens.spec.js
+++ b/test/html_to_tokens.spec.js
@@ -135,7 +135,6 @@ describe('htmlToTokens', function(){
             });
 
             it('should not close early on the first inner closing tag', function(){
-        
                 var atomic = '<span data-htmldiff-id="1"><span>a</span><span>b</span></span>';
                 expect(cut(atomic)).eql(tokenize([atomic]));
             });
@@ -148,6 +147,11 @@ describe('htmlToTokens', function(){
 
             it('should ignore self-closing same-named children when counting depth', function(){
                 var atomic = '<span data-htmldiff-id="1">x<span/>y</span>';
+                expect(cut(atomic)).eql(tokenize([atomic]));
+            });
+
+            it('should ignore self-closing same-named children written with a space (<span />)', function(){
+                var atomic = '<span data-htmldiff-id="1">x<span />y</span>';
                 expect(cut(atomic)).eql(tokenize([atomic]));
             });
 

--- a/test/html_to_tokens.spec.js
+++ b/test/html_to_tokens.spec.js
@@ -124,5 +124,38 @@ describe('htmlToTokens', function(){
                 ]
             ));
         });
+
+        describe('nested atomic tags wrapping', function(){
+            it('should keep a data-htmldiff-id wrapper with nested same-tag children as one token', function(){
+                var atomic = '<span data-htmldiff-id="u1">' +
+                        '<span class="tooltip"><span class="avatar">AB</span></span>' +
+                        'Name</span>';
+                expect(cut('<div>' + atomic + '</div>')).eql(
+                        tokenize(['<div>', atomic, '</div>']));
+            });
+
+            it('should not close early on the first inner closing tag', function(){
+        
+                var atomic = '<span data-htmldiff-id="1"><span>a</span><span>b</span></span>';
+                expect(cut(atomic)).eql(tokenize([atomic]));
+            });
+
+            it('should not treat a stray ">" in script content as a tag boundary', function(){
+                var atomic = '<script>if (a > b) { return a > 0; }</script>';
+                expect(cut('<p>' + atomic + '</p>')).eql(
+                        tokenize(['<p>', atomic, '</p>']));
+            });
+
+            it('should ignore self-closing same-named children when counting depth', function(){
+                var atomic = '<span data-htmldiff-id="1">x<span/>y</span>';
+                expect(cut(atomic)).eql(tokenize([atomic]));
+            });
+
+            it('should not bump depth on differently-named tags that share a prefix', function(){
+                // a tag must not be matched by an atomic tag named "a" appearing as <article>.
+                var atomic = '<a href="x"><article>hi</article></a>';
+                expect(cut(atomic)).eql(tokenize([atomic]));
+            });
+        });
     });
 });


### PR DESCRIPTION
[Ticket](https://matrixreq.atlassian.net/browse/M3X-720) 

This pull request introduces significant improvements to the HTML diffing logic, focusing on more robust handling of atomic tags.

### **ISSUE**
<img width="283" height="111" alt="image" src="https://github.com/user-attachments/assets/787fa20c-5d32-4750-b893-bd234f61272c" />

In html-diff when we have the tag with data-html-diff-id we consider them atomic and wrap them with ins/del. we decide opening and close of the atomic tag based on the tag name.

**Sometimes we might have a structure where** 
```html
<span data-htmldiff-id="testing">
  <span class="truncate">one</span>
  <span class="truncate">two</span>
</span>
``` 
then diffing algorithm finds the `data-htmldiff-id `starts the wrapping process it looks for the atomic tag which is `<span> `then it starts looking for the closing tag `</span>` but in our structure since it also has a child `<span>` the algorithm considers child's closing `</span>` as the parent one and produces something like this 

```html
<ins>
 <span data-htmldiff-id="testing">
   <span class="truncate">one</span>
</ins>
   <span class="truncate">two</span>
</span> // orphan tag
``` 
### **FIX**
So now we track how many tags with same name currently open inside the atomic token old code closed atomic tag at first </span> nested spans cut early broken markup.we count open/close depth, closes only when depth at 0 → whole nested block stays one balanced token.

<img width="564" height="189" alt="working version" src="https://github.com/user-attachments/assets/a09dea63-132d-48c1-93de-e8d986e53992" />

**Core logic improvements:**

* Improved handling of atomic tags (e.g., `<iframe>`, `<script>`, and custom tags with `data-htmldiff-id`), ensuring each atomic tag is wrapped independently in diffs, and supporting nested and adjacent atomic tags.

Fix counts open/close depth, closes only at depth 0 → whole nested block stays one balanced token.

**Testing and CI:**

* Added and updated tests for edge cases, atomic tag handling and HTML tokenization to ensure correctness and prevent regressions.

**Package metadata:**

* Updated `package.json` to reflect new ownership (`@matrixreq/htmldiff`), version bump to 1.4.0, and repository links.

These changes collectively make the diffing library more reliable for complex HTML structures and easier to maintain and test.